### PR TITLE
os.tmpdir in Firefox vs Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Also uses grunt-shell to launch `jpm test`.
 module.exports = function(grunt) {
     var istanbulJpm = require("istanbul-jpm");
 
+    process.env.coveragedir = require("os").tmpdir();
+
     grunt.initConfig({
         shell: {
             jpmTest: {
@@ -63,7 +65,7 @@ module.exports = function(grunt) {
 
     grunt.registerTask('readcoverageglobal', 'Reads the coverage global JPM wrote', function() {
         global.__coverage__ = require("istanbul-jpm/global-node").global.__coverage__;
-        grunt.log.ok("Read __coverage__ global stored in /tmp/istanbul-jpm-coverage.json");
+        grunt.log.ok("Read __coverage__ global");
     });
 
     grunt.registerTask('test', ['instrument', 'shell:jpmTest', 'readcoverageglobal', 'storeCoverage', 'makeReport']);

--- a/global-node.js
+++ b/global-node.js
@@ -8,7 +8,8 @@ const fs = require("fs");
 
 module.exports = {
     get global() {
-        var jsonFile = path.join(os.tmpdir(), "istanbul-jpm-coverage.json");
+        var coveragedir = process.env.coveragedir || os.tmpdir();
+        var jsonFile = path.join(coveragedir, "istanbul-jpm-coverage.json");
         return JSON.parse(fs.readFileSync(jsonFile));
     }
 };

--- a/global.js
+++ b/global.js
@@ -8,7 +8,8 @@ const system = require("sdk/system");
 exports.global = {};
 
 when(() => {
-    let stream = file.open(file.join(system.pathFor("TmpD"), "istanbul-jpm-coverage.json"), "w");
+    let coveragedir = system.env.coveragedir || system.pathFor("TmpD");
+    let stream = file.open(file.join(coveragedir, "istanbul-jpm-coverage.json"), "w");
     let string = JSON.stringify(exports.global);
     try {
         stream.write(string);


### PR DESCRIPTION
For me (at least) on OSX:

`global.js` writes to: `/Users/glind/Library/Caches/TemporaryItems/istanbul-jpm-coverage.json`  (ProfD tmp in Fx, obvs)

`global-node.js` wants to read from:  `file path: /var/folders/0z/4g3t_26s3gv835xswsslbn400000gq/T/istanbul-jpm-coverage.json`

Am I missing something?
